### PR TITLE
fix: deploy existing resources issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 .idea
 typescript/dist
 typescript/node_modules
+.DS_Store
+.aptos/

--- a/sources/devnet_coins.move
+++ b/sources/devnet_coins.move
@@ -4,6 +4,7 @@ module coin_list::devnet_coins {
     use std::signer;
     use std::string;
     use aptos_std::type_info;
+    use aptos_framework::coin::CoinInfo;
 
     struct DevnetBTC {}
     struct DevnetBNB {}
@@ -30,19 +31,21 @@ module coin_list::devnet_coins {
         symbol: vector<u8>,
         decimals: u8,
     ) {
-        let (burn, freeze, mint) =
-            coin::initialize<CoinType>(
-                admin,
-                utf8(name),
-                utf8(symbol),
-                decimals,
-                false
-            );
-        move_to(admin, CoinCaps {
-            mint,
-            freeze,
-            burn,
-        });
+        if (!coin::is_coin_initialized<CoinType>()) {
+            let (burn, freeze, mint) =
+                coin::initialize<CoinType>(
+                    admin,
+                    utf8(name),
+                    utf8(symbol),
+                    decimals,
+                    false
+                );
+            move_to(admin, CoinCaps{
+                mint,
+                freeze,
+                burn,
+            });
+        }
     }
 
     public fun mint<CoinType>(amount: u64): coin::Coin<CoinType> acquires CoinCaps {


### PR DESCRIPTION
## Problem
When publishing aptos-coin-list modules with an account and then calling `entry fun init_module`, it throws, a `code offset :number:` error, such as 

```
"Error": "Simulation failed with status: Execution failed in 0x23486fb5128d8e980e3c76c5faed996a5bf0076925c6fbc9598464b9e8d673ab::coin_list::initialize at code offset 20"
}
```

The reason is because the account module deployer already has the existent resources and `init_module` is trying to recreate them

## Changes
- Added validation for resources created in `init_module`
- Added common unnecessary files to `.gitignore`