### PR TITLE
update DLC logo url

### DIFF
--- a/typescript/src/defaultList.mainnet.json
+++ b/typescript/src/defaultList.mainnet.json
@@ -207,7 +207,7 @@
     "official_symbol": "DLC",
     "coingecko_id": "doglaikacoin",
     "decimals": 8,
-    "logo_url": "https://github.dev/hippospace/aptos-coin-list/blob/4e78f888b2ca0a348875ae26b91913a5f3b10fff/icons/DLC.svg",
+    "logo_url": "https://raw.githubusercontent.com/hippospace/aptos-coin-list/main/icons/DLC.svg",
     "project_url": "http://linktr.ee/doglaikacoin",
     "token_type": {
       "type": "0x84edd115c901709ef28f3cb66a82264ba91bfd24789500b6fd34ab9e8888e272::coin::DLC",

--- a/typescript/src/requestList.ts
+++ b/typescript/src/requestList.ts
@@ -928,7 +928,7 @@ export const REQUESTS: RawCoinInfo[] = [
     "official_symbol": "DLC",
     "coingecko_id": "doglaikacoin",
     "decimals": 8,
-    "logo_url": "https://github.dev/hippospace/aptos-coin-list/blob/4e78f888b2ca0a348875ae26b91913a5f3b10fff/icons/DLC.svg",
+    "logo_url": "https://raw.githubusercontent.com/hippospace/aptos-coin-list/main/icons/DLC.svg",
     "project_url": "http://linktr.ee/doglaikacoin",
     "token_type": {
       "type": "0x84edd115c901709ef28f3cb66a82264ba91bfd24789500b6fd34ab9e8888e272::coin::DLC",


### PR DESCRIPTION
The logo url in the recently merged commit was https://github.dev/hippospace/aptos-coin-list/blob/4e78f888b2ca0a348875ae26b91913a5f3b10fff/icons/DLC.svg, hence the logo was not showing on Hippo dex, therefore it has been updated to https://raw.githubusercontent.com/hippospace/aptos-coin-list/main/icons/DLC.svg

Thank you!